### PR TITLE
[15.0][FIX] web_widget_remote_measure: avoid fail on no device

### DIFF
--- a/web_widget_remote_measure/static/src/js/remote_measure_widget.esm.js
+++ b/web_widget_remote_measure/static/src/js/remote_measure_widget.esm.js
@@ -435,7 +435,7 @@ export const RemoteMeasure = FieldFloat.extend(RemoteMeasureMixin, {
      */
     start() {
         this._super(...arguments).then(() => {
-            if (this.remote_device_data.instant_read) {
+            if (this.remote_device_data && this.remote_device_data.instant_read) {
                 this.measure();
             }
         });


### PR DESCRIPTION
Error on property when the widget doesn't have a device data

please review @sergio-teruel @carlosdauden 