### PR TITLE
[15.0][FIX] stock_weighing: Stock move operations button is shown when all detailed operations already displayed

### DIFF
--- a/stock_weighing/models/stock_move.py
+++ b/stock_weighing/models/stock_move.py
@@ -223,6 +223,8 @@ class StockMove(models.Model):
             **ast.literal_eval(action["context"]),
             weight_operation_details=True
         )
+        # Clean context key show_weight_detail_buttons if any module add it
+        action["context"].pop("show_weight_detail_buttons", None)
         return action
 
     def action_print_weight_record_label(self):


### PR DESCRIPTION
cc @Tecnativa TT49524

ping @chienandalu 