### PR TITLE
[15.0][IMP] stock_weighing: Do not break workflow to record weight is user wants to print labels

### DIFF
--- a/stock_weighing/__manifest__.py
+++ b/stock_weighing/__manifest__.py
@@ -8,7 +8,12 @@
     "website": "https://github.com/OCA/stock-weighing",
     "license": "AGPL-3",
     "category": "Inventory",
-    "depends": ["stock", "web_filter_header_button", "web_widget_numeric_step"],
+    "depends": [
+        "stock",
+        "web_filter_header_button",
+        "web_widget_numeric_step",
+        "web_ir_actions_act_multi",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "views/start_screen_banner.xml",


### PR DESCRIPTION
cc @Tecnativa TT51483

When user wants record the weight he can click on enter key and the wizard is reloaded but if the print label option is checked the workflow is broken.
We need depend of web_ir_actions_act_multi module to allow print label and return de reload action wizard.

ping @chienandalu @carlosdauden 