### PR TITLE
[15][IMP] stock_weighing: Set move id in weigh wizard for access to other…

### DIFF
--- a/stock_weighing/models/stock_move_line.py
+++ b/stock_weighing/models/stock_move_line.py
@@ -37,6 +37,7 @@ class StockMoveLine(models.Model):
             default_weight=self[0].recorded_weight or self[0].qty_done,
             default_move_line_ids=self.ids,
             default_print_label=self.picking_type_id.print_weighing_label,
+            default_move_id=self.move_id.id,
         )
         return action
 


### PR DESCRIPTION
… models linked to move.

Very useful to access to production order linked to move 

cc @Tecnativa  TT51569

ping  @chienandalu @carlosdauden 