### PR TITLE
[15.0][IMP] stock_weighing: open groupby record

### DIFF
--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.esm.js
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.esm.js
@@ -12,6 +12,7 @@ export const WeightRecordingKanbanColumn = KanbanColumn.extend({
     events: _.extend({}, KanbanColumn.prototype.events || {}, {
         "click .toggle_kanban_fold": "_onToggleFold",
         "click .column_print_labels": "_onPrintLabels",
+        "click .o_column_open": "_onOpenColumn",
     }),
     /**
      * Show print button only when there are operations to print
@@ -30,6 +31,24 @@ export const WeightRecordingKanbanColumn = KanbanColumn.extend({
     _onPrintLabels(event) {
         event.preventDefault();
         this.trigger_up("column_print_labels");
+    },
+    /**
+     * Opens the related form view.
+     *
+     * @private
+     * @param {OdooEvent} ev
+     */
+    _onOpenColumn(event) {
+        event.preventDefault();
+        this.do_action({
+            context: {create: false},
+            type: "ir.actions.act_window",
+            target: "current",
+            views: [[false, "form"]],
+            res_model: this.relation,
+            res_id: this.id,
+            view_mode: "form",
+        });
     },
 });
 

--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.scss
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.scss
@@ -69,6 +69,10 @@
                 display: none;
             }
             .o_kanban_header_title {
+                .o_column_open {
+                    font-size: 1.3rem;
+                    font-weight: bold;
+                }
                 .o_column_title {
                     cursor: initial;
                 }

--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.xml
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.xml
@@ -27,6 +27,15 @@
             </button>
         </t>
         <t t-jquery=".o_column_unfold" t-operation="replace" />
+        <t t-jquery="span.o_column_title" t-operation="after">
+            <t t-if="!widget.folded and widget.grouped_by_m2o and widget.id">
+                <a
+                    role="image"
+                    class="ml-1 fa fa-external-link o_column_open"
+                    href="#"
+                />
+            </t>
+        </t>
     </t>
 
 </templates>


### PR DESCRIPTION
Add an access to the groupby record (if it's a related one) to be able to access to its full info.

cc @Tecnativa TT52202

please check @sergio-teruel @carlosdauden 

<del>I'm using the core `o_column_edit` method but maybe it'd would be more interesting to override it and open it with ir.actions.act_window</del>

**Updated**: finally using a `ir.actions.act_window` and a separate trigger for a more usable workflow:

![Peek 16-12-2024 14-10](https://github.com/user-attachments/assets/b7d61963-6a7c-4125-bedd-1d178f22e5d2)
