### PR TITLE
[15.0][IMP] stock_weighing: quantity_done

### DIFF
--- a/stock_weighing/views/stock_move_line_views.xml
+++ b/stock_weighing/views/stock_move_line_views.xml
@@ -80,9 +80,9 @@
                                 <!-- Weight value -->
                                 <div class="col-3">
                                     <div>
-                                        <t t-if="record.recorded_weight.raw_value">
+                                        <t t-if="record.qty_done.raw_value">
                                             <span class="h1 text-success">
-                                                <field name="recorded_weight" />
+                                                <field name="qty_done" />
                                             </span>
                                             <sup class="initialism">
                                                 <field name="product_uom_id" />

--- a/stock_weighing/views/stock_move_views.xml
+++ b/stock_weighing/views/stock_move_views.xml
@@ -21,6 +21,7 @@
                 <field name="product_uom_qty" />
                 <field name="product_qty" readonly="1" />
                 <field name="quantity_done" />
+                <field name="recorded_weight" />
                 <field name="reserved_availability" />
                 <field name="is_inventory" />
                 <field name="state" />
@@ -167,9 +168,9 @@
                                         t-attf-class="badge badge-{{record.recorded_weight.raw_value ? 'success' : 'light'}} w-100"
                                     >Qty. done</span>
                                     <div class="text-center">
-                                        <t t-if="record.recorded_weight.raw_value">
+                                        <t t-if="record.quantity_done.raw_value">
                                             <span class="h1 text-success">
-                                                <field name="recorded_weight" />
+                                                <field name="quantity_done" />
                                             </span>
                                             <sup class="initialism">
                                                 <field name="product_uom" />


### PR DESCRIPTION
Until now, the weighing cards just showed the recorded quantity, which is the one the user set from the weighing wizard. This could lead to confussion when a move has a quantity set from the wizard.

For the sake of clarity we put the quantity done while the logic for the recorded_weight field stays the same and could be shown in the future as a complementary information.

cc @Tecnativa TT52976

please review @sergio-teruel @carlosdauden 