### PR TITLE
[15.0][IMP] web_widget_remote_measure: Allow quick selection of the user's remote device

### DIFF
--- a/web_widget_remote_measure/README.rst
+++ b/web_widget_remote_measure/README.rst
@@ -48,6 +48,9 @@ To configure your remote devices:
 #. Create a new one configuring the required info.
 #. If the devices has an special port, set it up in the host data: e.g.: 10.1.1.2:3210
 
+If you want to see the button in the top bar to set the user's remote device, you need
+to have the "Show remote device button on navbar" group.
+
 Usage
 =====
 
@@ -67,6 +70,9 @@ provide an uom field so records that aren't in that UoM don't measure from the d
 .. code:: xml
 
     <field name="float_field" widget="remote_measure" options="{'remote_device_field': 'measure_device_id', 'uom_field': 'uom_id'}" />
+
+The users are able to change their default remote device by using the button with the
+balance icon set on the navbar.
 
 Known issues / Roadmap
 ======================
@@ -107,6 +113,7 @@ Contributors
 
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_widget_remote_measure/__manifest__.py
+++ b/web_widget_remote_measure/__manifest__.py
@@ -14,6 +14,7 @@
         "views/remote_measure_device_views.xml",
         "views/res_users_views.xml",
         "security/ir.model.access.csv",
+        "security/security.xml",
     ],
     "assets": {
         "web.assets_backend": [

--- a/web_widget_remote_measure/models/res_users.py
+++ b/web_widget_remote_measure/models/res_users.py
@@ -10,3 +10,8 @@ class ResUsers(models.Model):
         comodel_name="remote.measure.device",
         help="Default remote measure device for this user",
     )
+
+    def action_close_remote_device_wizard(self):
+        return {
+            "type": "ir.actions.act_window_close",
+        }

--- a/web_widget_remote_measure/readme/CONFIGURE.rst
+++ b/web_widget_remote_measure/readme/CONFIGURE.rst
@@ -3,3 +3,6 @@ To configure your remote devices:
 #. Go to *Settings > Technical > Devices > Remote devices*
 #. Create a new one configuring the required info.
 #. If the devices has an special port, set it up in the host data: e.g.: 10.1.1.2:3210
+
+If you want to see the button in the top bar to set the user's remote device, you need
+to have the "Show remote device button on navbar" group.

--- a/web_widget_remote_measure/readme/CONTRIBUTORS.rst
+++ b/web_widget_remote_measure/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 
   * David Vidal
   * Sergio Teruel
+  * Carlos Roca

--- a/web_widget_remote_measure/readme/USAGE.rst
+++ b/web_widget_remote_measure/readme/USAGE.rst
@@ -14,3 +14,6 @@ provide an uom field so records that aren't in that UoM don't measure from the d
 .. code:: xml
 
     <field name="float_field" widget="remote_measure" options="{'remote_device_field': 'measure_device_id', 'uom_field': 'uom_id'}" />
+
+The users are able to change their default remote device by using the button with the
+balance icon set on the navbar.

--- a/web_widget_remote_measure/security/security.xml
+++ b/web_widget_remote_measure/security/security.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="remote_device_button_group" model="res.groups">
+        <field name="name">Show remote device button on navbar</field>
+        <field name="users" eval="[Command.link(ref('base.user_admin'))]" />
+    </record>
+</odoo>

--- a/web_widget_remote_measure/static/description/index.html
+++ b/web_widget_remote_measure/static/description/index.html
@@ -397,6 +397,8 @@ Webservices.</p>
 <li>Create a new one configuring the required info.</li>
 <li>If the devices has an special port, set it up in the host data: e.g.: 10.1.1.2:3210</li>
 </ol>
+<p>If you want to see the button in the top bar to set the user’s remote device, you need
+to have the “Show remote device button on navbar” group.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -414,6 +416,8 @@ provide an uom field so records that aren’t in that UoM don’t measure from t
 <pre class="code xml literal-block">
 <span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;float_field&quot;</span><span class="w"> </span><span class="na">widget=</span><span class="s">&quot;remote_measure&quot;</span><span class="w"> </span><span class="na">options=</span><span class="s">&quot;{'remote_device_field': 'measure_device_id', 'uom_field': 'uom_id'}&quot;</span><span class="w"> </span><span class="nt">/&gt;</span>
 </pre>
+<p>The users are able to change their default remote device by using the button with the
+balance icon set on the navbar.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
@@ -451,6 +455,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
 <li>Sergio Teruel</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>

--- a/web_widget_remote_measure/static/src/js/systray_device_selector.esm.js
+++ b/web_widget_remote_measure/static/src/js/systray_device_selector.esm.js
@@ -1,0 +1,48 @@
+/* @odoo-module */
+/* Copyright 2025 Tecnativa - Carlos Roca
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+import {registry} from "@web/core/registry";
+import {useService} from "@web/core/utils/hooks";
+const {onWillStart} = owl.hooks;
+const {Component} = owl;
+
+export class SelectRemoteDeviceMenu extends Component {
+    setup() {
+        this.action = useService("action");
+        this.user = useService("user");
+        onWillStart(async () => {
+            this.isRemoteDeviceUser = await this.user.hasGroup(
+                "web_widget_remote_measure.remote_device_button_group"
+            );
+        });
+    }
+
+    /**
+     * Go to user init action when clicking it
+     * @private
+     */
+    async onClickSelectRemoteDevice() {
+        const action = await this.action.loadAction(
+            "web_widget_remote_measure.action_user_remote_device_selector"
+        );
+        action.res_id = this.user.userId;
+        this.action.doAction(action);
+    }
+}
+
+SelectRemoteDeviceMenu.template =
+    "web_widget_remote_measure.RemoteDeviceSelectorButton";
+
+export const systrayRemoteDeviceSelector = {
+    Component: SelectRemoteDeviceMenu,
+};
+
+registry
+    .category("systray")
+    .add(
+        "web_widget_remote_measure.remote_device_selector_button",
+        systrayRemoteDeviceSelector,
+        {
+            sequence: 100,
+        }
+    );

--- a/web_widget_remote_measure/static/src/xml/systray_device_selector.xml
+++ b/web_widget_remote_measure/static/src/xml/systray_device_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+    <t t-name="web_widget_remote_measure.RemoteDeviceSelectorButton" owl="1">
+        <div class="div_remote_device_selector">
+            <a
+                name="remote_device_selector"
+                title="Select user remote device"
+                href="#"
+                role="button"
+                t-on-click="onClickSelectRemoteDevice"
+                t-if="isRemoteDeviceUser"
+            >
+                <i
+                    class="fa fa-lg fa-balance-scale"
+                    role="img"
+                    aria-label="Select user remote device"
+                />
+            </a>
+        </div>
+    </t>
+</templates>

--- a/web_widget_remote_measure/views/res_users_views.xml
+++ b/web_widget_remote_measure/views/res_users_views.xml
@@ -28,4 +28,29 @@
             </group>
         </field>
     </record>
+    <record id="view_users_select_remote_measure_form" model="ir.ui.view">
+        <field name="name">res.users.select.remote.measure.device</field>
+        <field name="model">res.users</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="remote_measure_device_id" widget="selection_badge" />
+                <footer>
+                    <button
+                        type="object"
+                        name="action_close_remote_device_wizard"
+                        string="Confirm"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record model="ir.actions.act_window" id="action_user_remote_device_selector">
+        <field name="name">Select remote measure device</field>
+        <field name="res_model">res.users</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_users_select_remote_measure_form" />
+        <field name="target">new</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Sometimes, a user may be working from different devices (if they're an operator) or moving around the company with a tablet and needs to weigh using the nearest device, without losing focus on their current task.

With these changes, we allow them to quickly switch remote devices without having to access their user profile.

cc @Tecnativa TT55929

ping @sergio-teruel @carlosdauden 