### PR TITLE
[17.0][FIX] web_widget_remote_measure: Avoid error when catching remote_device id from users defined

### DIFF
--- a/web_widget_remote_measure/__manifest__.py
+++ b/web_widget_remote_measure/__manifest__.py
@@ -19,6 +19,7 @@
     "assets": {
         "web.assets_backend": [
             "web_widget_remote_measure/static/src/remote_measure_field/**/*",
+            "web_widget_remote_measure/static/src/systray/**/*",
         ],
     },
 }

--- a/web_widget_remote_measure/static/src/remote_measure_field/remote_measure_field.esm.js
+++ b/web_widget_remote_measure/static/src/remote_measure_field/remote_measure_field.esm.js
@@ -51,7 +51,7 @@ export class RemoteMeasureField extends FloatField {
             [this.remote_device_data.id] =
                 this.props.record.data[this.props.remote_device_field];
         } else if (this.default_user_device) {
-            [this.remote_device_data.id] = this.default_user_device;
+            this.remote_device_data.id = this.default_user_device;
         }
         if (!this.uom && this.props.uom_field) {
             [this.uom] = this.props.record.data[this.props.uom_field];

--- a/web_widget_remote_measure/static/src/systray/systray_device_selector.esm.js
+++ b/web_widget_remote_measure/static/src/systray/systray_device_selector.esm.js
@@ -2,11 +2,11 @@
 /* Copyright 2025 Tecnativa - Carlos Roca
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
 import {registry} from "@web/core/registry";
+import {Component, onWillStart} from "@odoo/owl";
 import {useService} from "@web/core/utils/hooks";
-const {onWillStart} = owl.hooks;
-const {Component} = owl;
 
 export class SelectRemoteDeviceMenu extends Component {
+    static template = "web_widget_remote_measure.RemoteDeviceSelectorButton";
     setup() {
         this.action = useService("action");
         this.user = useService("user");
@@ -29,9 +29,6 @@ export class SelectRemoteDeviceMenu extends Component {
         this.action.doAction(action);
     }
 }
-
-SelectRemoteDeviceMenu.template =
-    "web_widget_remote_measure.RemoteDeviceSelectorButton";
 
 export const systrayRemoteDeviceSelector = {
     Component: SelectRemoteDeviceMenu,

--- a/web_widget_remote_measure/static/src/systray/systray_device_selector.scss
+++ b/web_widget_remote_measure/static/src/systray/systray_device_selector.scss
@@ -1,0 +1,11 @@
+.div_remote_device_selector {
+    button {
+        height: 100%;
+        color: white;
+
+        &:hover {
+            background-color: rgba(0, 0, 0, 0.075);
+            color: white;
+        }
+    }
+}

--- a/web_widget_remote_measure/static/src/systray/systray_device_selector.xml
+++ b/web_widget_remote_measure/static/src/systray/systray_device_selector.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
-    <t t-name="web_widget_remote_measure.RemoteDeviceSelectorButton" owl="1">
+    <t t-name="web_widget_remote_measure.RemoteDeviceSelectorButton">
         <div class="div_remote_device_selector">
-            <a
+            <button
                 name="remote_device_selector"
+                class="btn btn-link"
                 title="Select user remote device"
                 href="#"
-                role="button"
                 t-on-click="onClickSelectRemoteDevice"
                 t-if="isRemoteDeviceUser"
             >
@@ -15,7 +15,7 @@
                     role="img"
                     aria-label="Select user remote device"
                 />
-            </a>
+            </button>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
cc @Tecnativa TT52413

When there is no field to select the remote device and the option to use the user's default device is set, an error occurs because the value is already an ID, so it is not correct to extract it from any list.

Fixed too the button to select the remote device

ping @sergio-teruel @carlos-lopez-tecnativa 