### PR TITLE
[15.0][IMP] stock_weighing: Add a button to set reserved qty to done qty

### DIFF
--- a/stock_weighing/models/stock_move.py
+++ b/stock_weighing/models/stock_move.py
@@ -301,3 +301,12 @@ class StockMove(models.Model):
         action["context"] = dict(search_default_to_weigh=1, **action["context"])
         action["name"] = _("Weigh incoming")
         return action
+
+    def set_product_uom_qty_to_qty_done_from_weighing(self):
+        self.ensure_one()
+        for move_line in self.filtered(lambda line: not line.has_weight).move_line_ids:
+            move_line.qty_done = move_line.product_uom_qty
+            move_line.recorded_weight = move_line.product_uom_qty
+            move_line.has_recorded_weight = True
+            move_line.weighing_user_id = self.env.user
+            move_line.weighing_date = fields.Datetime.now()

--- a/stock_weighing/views/stock_move_views.xml
+++ b/stock_weighing/views/stock_move_views.xml
@@ -147,6 +147,16 @@
                                             class="btn btn-lg border"
                                             t-elif="record.move_lines_count.raw_value > 1 &amp;&amp; context.hide_weight_detail_buttons &amp;&amp; record.weighing_state.raw_value === 'weighing'"
                                         ><i class="fa fa-check text-success" /></button>
+                                        <button
+                                            string="Set reserved to done"
+                                            title="Set reserved to done"
+                                            name="set_product_uom_qty_to_qty_done_from_weighing"
+                                            type="object"
+                                            class="btn btn-lg border ml-2"
+                                            t-if="!record.has_weight.raw_value and record.reserved_availability.raw_value !== record.quantity_done.raw_value"
+                                        ><i
+                                                class="fa fa-arrow-right text-success"
+                                            /></button>
                                     </div>
                                 </div>
                                 <!-- Weight -->


### PR DESCRIPTION
When the entries are not weighing operations, in the 90% of operations the user wants to set the reservation to done. Adding this button they are saving like 10 sec by operation.

![ejemplo_cantidad_reservada_a_hecho](https://github.com/user-attachments/assets/1034b76e-7b7e-42d6-b51c-b053fb1f6def)

cc @Tecnativa TT56678

ping @sergio-teruel @carlosdauden 