### PR TITLE
[15.0][FIX] web_widget_remote_measure: Error when the widget is not being used

### DIFF
--- a/web_widget_remote_measure/static/src/js/remote_measure_widget.esm.js
+++ b/web_widget_remote_measure/static/src/js/remote_measure_widget.esm.js
@@ -465,9 +465,11 @@ export const RemoteMeasure = FieldFloat.extend(RemoteMeasureMixin, {
      */
     start() {
         this._super(...arguments).then(() => {
-            setTimeout(() => {
-                selectInputWhenVisible(this.$input);
-            }, 0);
+            if (this.$input) {
+                setTimeout(() => {
+                    selectInputWhenVisible(this.$input);
+                }, 0);
+            }
             if (this.remote_device_data && this.remote_device_data.instant_read) {
                 this.measure();
             }


### PR DESCRIPTION
When the widget is not being used, it might still go through the start function. This check prevents the helper from being triggered when there is no input to select.

cc @Tecnativa TT56847

ping @carlosdauden @pedrobaeza 