### PR TITLE
[15.0][FIX] stock_weighing_remote_measure: stop weighing when adding a tare

### DIFF
--- a/stock_weighing_remote_measure/static/src/js/weight_record_form_widget.esm.js
+++ b/stock_weighing_remote_measure/static/src/js/weight_record_form_widget.esm.js
@@ -112,6 +112,7 @@ export const RemoteMeasureForm = RemoteMeasure.extend({
     /* TARE METHODS */
 
     _updateTare() {
+        this.measure_stop();
         this.$tare_amount.text(this.format_weight(this.tare));
         this.$real_amount.text(this.format_weight(this.amount));
         this._setMeasure();


### PR DESCRIPTION
If the weighing continues the tare can be not added to the weight, it seems to be caused by a race condition, but I haven’t been able to prevent it.

To avoid the problem right now, the only way that i found to do it is stopping the measure before registering a tare.

ping @sergio-teruel @carlosdauden 

cc @Tecnativa TT58429