### PR TITLE
[15.0][IMP] stock_weighing: Take care about config parameter to show the smart button

### DIFF
--- a/stock_weighing/models/stock_picking.py
+++ b/stock_weighing/models/stock_picking.py
@@ -3,6 +3,7 @@
 import ast
 
 from odoo import _, api, fields, models
+from odoo.tools.misc import str2bool
 
 
 class StockPicking(models.Model):
@@ -13,8 +14,17 @@ class StockPicking(models.Model):
 
     @api.depends("move_lines")
     def _compute_has_weighing_operations(self):
-        for picking in self:
-            picking.has_weighing_operations = picking.move_lines.filtered("has_weight")
+        if str2bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("stock_weighing.any_operation_actions")
+        ):
+            self.has_weighing_operations = True
+        else:
+            for picking in self:
+                picking.has_weighing_operations = picking.move_lines.filtered(
+                    "has_weight"
+                )
 
     def action_weighing_operations(self):
         """Weighing operations for this picking"""


### PR DESCRIPTION
Before these changes, we can see the stock moves that not require weighing accessing from weighing interface, but it cannot be accessed from the pickings.

With these changes, they will be accessible from pickings.

cc @Tecnativa TT60776

ping @sergio-teruel @carlosdauden 