### PR TITLE
[18.0][IMP] web_widget_remote_measure: Add possibility to record extraMeasures

### DIFF
--- a/web_widget_remote_measure/static/src/remote_measure_field/remote_measure_field.esm.js
+++ b/web_widget_remote_measure/static/src/remote_measure_field/remote_measure_field.esm.js
@@ -104,6 +104,13 @@ export class RemoteMeasureField extends FloatField {
         onWillUnmount(() => this._closeSocket());
     }
 
+    /**
+     * Getter to allow set extra measures to the main input
+     */
+    get extraMeasures() {
+        return 0;
+    }
+
     // Private methods
 
     async _assignDevice() {
@@ -239,7 +246,7 @@ export class RemoteMeasureField extends FloatField {
         if (this.state.start_add) {
             this.amount += this.state.input_val;
         }
-        this.props.record.update({[this.props.name]: this.amount});
+        this.props.record.update({[this.props.name]: this.amount + this.extraMeasures});
     }
     nextStateIcon() {
         this.state.icon = nextState[this.state.icon];


### PR DESCRIPTION
With this changes we are able to extend the extraMeasures getter to be able to add the measures needed, per example, to add tares to the input.

cc @Tecnativa TT54360

ping @sergio-teruel @Andrii9090-tecnativa 