### PR TITLE
[15.0][FIX] stock_weighing: Add default_move_id to the context in action_weighing (stock.move)

### DIFF
--- a/stock_weighing/models/stock_move.py
+++ b/stock_weighing/models/stock_move.py
@@ -188,6 +188,7 @@ class StockMove(models.Model):
             default_weight=self.recorded_weight or self.quantity_done,
             default_move_line_ids=self.move_line_ids.ids,
             default_print_label=self._get_default_print_label(),
+            default_move_id=self.id,
         )
         return action
 


### PR DESCRIPTION
@sergio-teruel can you review please?

@Tecnativa