### PR TITLE
[18.0][FIX] stock_weighing: Fix folded kanban

### DIFF
--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.scss
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.scss
@@ -4,6 +4,12 @@
 .o_kanban_view.o_weight_kanban {
     overflow: auto;
     border-top: 1px solid $border-color;
+    .flex-basis-0 {
+        flex-basis: auto !important;
+    }
+    .o_column_unfold {
+        display: none !important;
+    }
     .o_kanban_ungrouped {
         padding: 0px;
         --KanbanRecord-width: 100vw;

--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.xml
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.xml
@@ -8,7 +8,7 @@
         <xpath expr="//t[@t-esc='groupName']" position="before">
             <span class="me-2">
                 <i
-                    class="fa fa-folder-open text-warning"
+                    class="fa fa-folder text-warning"
                     role="button"
                     aria-label="Fold"
                     title="Fold"
@@ -19,7 +19,7 @@
         <xpath expr="//span[@t-esc='groupName']" position="before">
             <span class="me-2">
                 <i
-                    class="fa fa-folder text-warning"
+                    class="fa fa-folder-open text-warning"
                     role="button"
                     aria-label="Unfold"
                     title="Unfold"


### PR DESCRIPTION
With this [commit](https://github.com/OCA/OCB/commit/c964329addd2e4fbc62db1236765d25f86243d14#diff-4de8437424d1b687477e865e387b017fc5a6a86e9c50c9ea198da79d3a7a1a4cR298) Odoo adds `flex-basis-0` class when the kanban view is folded.

<img width="1280" height="613" alt="chrome-capture-2026-04-20" src="https://github.com/user-attachments/assets/09ea8fc8-73a0-4ad9-89cf-c43dea5388c4" />


@CarlosRoca13 @sergio-teruel ping
@Tecnativa 
TT54358