### PR TITLE
[18.0][FIX] stock_weighing: Post migration to update menuitem

### DIFF
--- a/stock_weighing/__manifest__.py
+++ b/stock_weighing/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Weighing assistant",
     "summary": "Weighing assistant for stock operations",
-    "version": "18.0.1.0.3",
+    "version": "18.0.1.0.4",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-weighing",
     "license": "AGPL-3",

--- a/stock_weighing/migrations/18.0.1.0.4/noupdate_changes.xml
+++ b/stock_weighing/migrations/18.0.1.0.4/noupdate_changes.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <data>
+        <delete
+            model="ir.actions.act_window"
+            id="stock_weighing.stock_move_weight_operation_start_screen"
+        />
+        <record id="stock_move_weight_operation_start_screen" model="ir.actions.server">
+            <field name="name">Weight</field>
+            <field name="path">weigh</field>
+            <field
+                name="model_id"
+                ref="web_quick_start_screen.model_quick_start_screen"
+            />
+            <field name="state">code</field>
+            <field name="code">
+action = env.ref('stock_weighing.quick_start_screen_weighing').action_screen_actions()
+        </field>
+        </record>
+        <record id="menu_weight_operation_screen" model="ir.ui.menu">
+            <field
+                name="action"
+                ref="stock_weighing.stock_move_weight_operation_start_screen"
+            />
+        </record>
+    </data>
+</odoo>

--- a/stock_weighing/migrations/18.0.1.0.4/post-migrate.py
+++ b/stock_weighing/migrations/18.0.1.0.4/post-migrate.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Tecnativa - Andrii Kompaniiets
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env, "stock_weighing", "migrations/18.0.1.0.4/noupdate_changes.xml"
+    )


### PR DESCRIPTION
It need to update menuitem, change model (`ir.actions.act_window` -> `ir.actions.server`) for `stock_move_weight_operation_start_screen` and show Weighing in menu.

@CarlosRoca13 @sergio-teruel ping
@Tecnativa