### PR TITLE
[18.0][FIX] stock_weighing: Add export to WeightRecordingKanbanHeader

### DIFF
--- a/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.esm.js
+++ b/stock_weighing/static/src/base_weight_record_kanban/base_weight_record_kanban.esm.js
@@ -6,7 +6,7 @@ import {kanbanView} from "@web/views/kanban/kanban_view";
 import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";
 
-class WeightRecordingKanbanHeader extends KanbanHeader {
+export class WeightRecordingKanbanHeader extends KanbanHeader {
     static template = "stock_weighing.KanbanHeader";
     setup() {
         super.setup();


### PR DESCRIPTION
This fix allows extending `WeightRecordingKanbanHeader` and using it in other modules

@chienandalu can you review please?

@Tecnativa
TT62144