### PR TITLE
[18.0][FIX] stock_weighing: Add migrate script to sync quantity->qty_picked

### DIFF
--- a/stock_weighing/migrations/18.0.1.0.0/post-migrate.py
+++ b/stock_weighing/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Tecnativa - Andrii Kompaniiets
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def _update_qty_picked(env):
+    """
+    It needs to sync the new qty_picked field with the quantity when the
+    state is done or when a weight is recorded on stock.move / stock.move.line
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE stock_move
+            SET qty_picked=quantity
+            WHERE weighing_state='weighed' OR state='done'
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE stock_move_line
+            SET qty_picked=quantity
+            WHERE has_recorded_weight=true OR state='done'
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _update_qty_picked(env)


### PR DESCRIPTION
It needs to sync the new `qty_picked` field with the quantity when the state is done or when a weight is recorded on stock.move / stock.move.line.

In Odoo v18, the `qty_done` field didn’t exist. This module introduces `qty_picked` to track the picked quantity. Without this migration script, the "Done" value in the weighing assistant always shows 0.00, since it is based on `qty_picked`.

@CarlosRoca13 @sergio-teruel can you review please?
@Tecnativa