### PR TITLE
[18.0][FIX] stock_weighing: Add Interwarehouse to start screen

### DIFF
--- a/stock_weighing/__manifest__.py
+++ b/stock_weighing/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Weighing assistant",
     "summary": "Weighing assistant for stock operations",
-    "version": "18.0.1.0.7",
+    "version": "18.0.1.0.8",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-weighing",
     "license": "AGPL-3",

--- a/stock_weighing/data/quick_start_screens.xml
+++ b/stock_weighing/data/quick_start_screens.xml
@@ -32,11 +32,27 @@
         <field name="icon_name">fa-arrow-right</field>
         <field name="color">7</field>
     </record>
+    <record
+        id="quick_start_screen_action_interwarehouse_any_operations"
+        model="quick.start.screen.action"
+    >
+        <field name="name">Interwarehouse (weighing)</field>
+        <field name="description">Interwarehouse weighing operations</field>
+        <field name="action_ref_id" ref="stock_weighing.weighing_operation_action" />
+        <field name="domain">[
+            ("location_id.usage", "in", ["internal", "transit"]),
+            ("location_dest_id.usage", "in", ["internal", "transit"]),
+            ("picking_type_id.weighing_operations", "=", True),
+        ]</field>
+        <field name="context">{'show_weight_detail_buttons': True}</field>
+        <field name="icon_name">fa-arrows-h</field>
+        <field name="color">7</field>
+    </record>
     <record id="quick_start_screen_weighing" model="quick.start.screen">
         <field name="name">Weighing</field>
         <field
             name="action_ids"
-            eval="[Command.link(ref('stock_weighing.quick_start_screen_action_incoming_any_operations')), Command.link(ref('stock_weighing.quick_start_screen_action_outgoing_any_operations'))]"
+            eval="[Command.link(ref('stock_weighing.quick_start_screen_action_incoming_any_operations')), Command.link(ref('stock_weighing.quick_start_screen_action_outgoing_any_operations')), Command.link(ref('stock_weighing.quick_start_screen_action_interwarehouse_any_operations'))]"
         />
     </record>
     <record id="stock_move_weight_operation_start_screen" model="ir.actions.server">

--- a/stock_weighing/migrations/18.0.1.0.8/noupdate_changes.xml
+++ b/stock_weighing/migrations/18.0.1.0.8/noupdate_changes.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <data>
+        <record
+            id="quick_start_screen_action_interwarehouse_any_operations"
+            model="quick.start.screen.action"
+        >
+            <field name="name">Interwarehouse (weighing)</field>
+            <field name="description">Interwarehouse weighing operations</field>
+            <field
+                name="action_ref_id"
+                ref="stock_weighing.weighing_operation_action"
+            />
+            <field name="domain">[
+            ("location_id.usage", "in", ["internal", "transit"]),
+            ("location_dest_id.usage", "in", ["internal", "transit"]),
+            ("picking_type_id.weighing_operations", "=", True),
+        ]</field>
+            <field name="context">{'show_weight_detail_buttons': True}</field>
+            <field name="icon_name">fa-arrows-h</field>
+            <field name="color">7</field>
+        </record>
+        <record id="quick_start_screen_weighing" model="quick.start.screen">
+            <field
+                name="action_ids"
+                eval="[Command.link(ref('stock_weighing.quick_start_screen_action_interwarehouse_any_operations'))]"
+            />
+        </record>
+    </data>
+</odoo>

--- a/stock_weighing/migrations/18.0.1.0.8/post-migrate.py
+++ b/stock_weighing/migrations/18.0.1.0.8/post-migrate.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Tecnativa - Andrii Kompaniiets
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env, "stock_weighing", "migrations/18.0.1.0.8/noupdate_changes.xml"
+    )


### PR DESCRIPTION
During the migration process, the Itrawerehouse Operation menu has been lost.

https://github.com/OCA/stock-weighing/blob/15.0/stock_weighing/models/stock_move.py#L285

@sergio-teruel @CarlosRoca13 ping
@Tecnativa