### PR TITLE
[18.0][FIX] stock_weighing: Skip quantity sync for unweighed lines on validate

### DIFF
--- a/stock_weighing/models/stock_picking.py
+++ b/stock_weighing/models/stock_picking.py
@@ -41,10 +41,11 @@ class StockPicking(models.Model):
         return action
 
     def button_validate(self):
+        # Only sync quantity from the weighing wizard result; skip lines completed
+        # directly from the reception screen (no recorded weight) to avoid zeroing them.
         move_lines_with_weight = self.move_ids.move_line_ids.filtered("has_weight")
         for move_line in move_lines_with_weight:
-            if move_line.qty_picked > 0:
-                move_line.quantity = move_line.qty_picked
-            else:
-                move_line.quantity = 0
+            if not move_line.has_recorded_weight:
+                continue
+            move_line.quantity = move_line.qty_picked
         return super().button_validate()


### PR DESCRIPTION
Skip overwriting quantity for kg move lines that were completed directly from the reception screen without going through the weighing wizard, as `qty_picked` is 0 in that case and was zeroing out the line quantity

cc @Tecnativa TT62479

ping @sergio-teruel @Andrii9090-tecnativa 