### PR TITLE
[18.0][FIX] stock_weighing: Kanban view

### DIFF
--- a/stock_weighing/views/stock_move_views.xml
+++ b/stock_weighing/views/stock_move_views.xml
@@ -122,6 +122,7 @@
                                 <div class="col-1">
                                     <div
                                         t-if="!['done', 'cancel', 'draft'].includes(record.state.raw_value)"
+                                        class="d-flex flex-column flex-xl-row align-items-center gap-2"
                                     >
                                         <button
                                             string="Record weight"
@@ -161,7 +162,7 @@
                                             title="Set reserved to done"
                                             name="set_product_uom_qty_to_qty_done_from_weighing"
                                             type="object"
-                                            class="btn btn-lg border ms-2"
+                                            class="btn btn-lg border"
                                             t-if="!record.has_weight.raw_value and record.quantity.raw_value !== record.qty_picked.raw_value"
                                         >
                                             <i class="fa fa-arrow-right text-success" />


### PR DESCRIPTION
One small fix in the kanban view
Before 
<img width="1754" height="448" alt="image" src="https://github.com/user-attachments/assets/903314db-5cdf-4759-9af7-171cb5aef79a" />

After
<img width="1129" height="327" alt="image" src="https://github.com/user-attachments/assets/b7fe1be1-8726-4152-8f51-0df6f5bbdf81" />
<img width="1129" height="327" alt="image" src="https://github.com/user-attachments/assets/39f1c046-53e0-461a-a464-5759619cc223" />

@sergio-teruel @CarlosRoca13 ping
@Tecnativa
TT62991